### PR TITLE
Poprawiono nazwe zrzut ekranu w pliku  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ Otwórz plik `index.html` w przeglądarce, aby przejść do używania.
 Ten projekt jest dostępny na licencji MIT.
 
 
-[zrzut-obraz]: index.html/zasobu/zrzut_ekranu-giełda_domen_plik.readme.md.png "Zrzut ekranu"
+[zrzut-obraz]: ./index.html/zasobu/zrzut_ekranu-giełda_domen_plik.readme.md.png "Zrzut ekranu"
 [watchYouTubeShort]: https://youtube.com/shorts/lLUIFieyUPs?si=g5q1jRpHASltx2Q5


### PR DESCRIPTION
Poprawiono nazwe zrzut ekranu w pliku  README.md prawdopodobnie niewłaściwie. Podjęta będzie kolejna poprawka.