### PR TITLE
Poprawiono link do logo w sekcji promotion w pliku aboutn.html

### DIFF
--- a/podfoldern/aboutn.html
+++ b/podfoldern/aboutn.html
@@ -89,7 +89,7 @@ publishable-key="pk_live_51Ne3NEIMvKBMrhlEjYDipe2Y6fMD63oXUUQ9WKwshadTTQqXRUtlhB
                 <p>Skopiuj poniższy kod HTML i wklej go na swoją witrynę:</p>
                 <textarea readonly style="width: 100%; height: 100px; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9;">
             <a href="https://mplik.github.io/domeny-web/" target="_blank">
-                <img src="https://imgur.com/gallery/wnbQvHc" alt="Opis ikony" style="width: 20px; height: 20px;">
+                <img src="https://raw.githubusercontent.com/mplik/domeny-web/main/podfoldern/images/logo/logo_mplik.pl.png" alt="Opis ikony" style="width: 20px; height: 20px;">
                 Giełda Domen MPLIK.PL
             </a>
                 </textarea>


### PR DESCRIPTION
Poprawiono link do logo w sekcji promotion w pliku aboutn.html
[logo](https://github.com/mplik/domeny-web/blob/main/podfoldern/images/logo/logo_mplik.pl.png)