### PR TITLE
Poprawiono link do logo dodano opis w pliku aboutn.html

### DIFF
--- a/podfoldern/aboutn.html
+++ b/podfoldern/aboutn.html
@@ -82,14 +82,14 @@ publishable-key="pk_live_51Ne3NEIMvKBMrhlEjYDipe2Y6fMD63oXUUQ9WKwshadTTQqXRUtlhB
                 </a>
             </div>
             </div>
-            <details>
+            <details> <!-- Dodaje link do pobrania i osadzenia na stronie użytkownika -->
                 <summary>Dodaj link do naszej aplikacji na swoją stronę</summary>
-            <div class="promotion">
-                <h4>Dodaj link do naszej aplikacji na swoją stronę</h4>
+            <div class="promotion">  
+                <h4>Dodaj link do naszej aplikacji na swoją stronę</h4>  
                 <p>Skopiuj poniższy kod HTML i wklej go na swoją witrynę:</p>
                 <textarea readonly style="width: 100%; height: 100px; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9;">
             <a href="https://mplik.github.io/domeny-web/" target="_blank">
-                <img src="https://raw.githubusercontent.com/mplik/domeny-web/main/podfoldern/images/logo/logo_mplik.pl.png" alt="Opis ikony" style="width: 20px; height: 20px;">
+                <img src="https://github.com/mplik/domeny-web/blob/main/podfoldern/images/logo/logo_mplik.pl.png" alt="MPLIK.PL" style="width: 20px; height: 20px;">
                 Giełda Domen MPLIK.PL
             </a>
                 </textarea>


### PR DESCRIPTION
Poprawiono link do logo dodano opis w pliku aboutn.html
[logo](https://github.com/mplik/domeny-web/blob/main/podfoldern/images/logo/logo_mplik.pl.png )