### PR TITLE
Poprawiono literówkę w domenie carlito.pl w sold-domains.json

### DIFF
--- a/sold-domains.json
+++ b/sold-domains.json
@@ -1,6 +1,6 @@
 [
   {
-    "domain": "carlit.pl",
+    "domain": "carlito.pl",
     "date": "2024-01-16",
     "price": "30 zł"
   },


### PR DESCRIPTION
Poprawiono literówkę w domenie carlito.pl w sold-domains.json