### PR TITLE
Poprawka: padding-right dla .main-title na mobile, aby tytuł nie nach…

### DIFF
--- a/stylesn.css
+++ b/stylesn.css
@@ -16,6 +16,7 @@
         position: relative;
         text-align: left;
         padding-left: 32px;
+        padding-right: 40px;
     }
     .main-title .panel-link {
         position: absolute;


### PR DESCRIPTION
…odził na ikonę panelu klienta
Poprawka: padding-right dla .main-title na mobile, aby tytuł nie nach…